### PR TITLE
Added support for deserializing login roles_limit

### DIFF
--- a/src/main/java/ca/gc/cyber/ops/assemblyline/java/client/model/LoginResponse.java
+++ b/src/main/java/ca/gc/cyber/ops/assemblyline/java/client/model/LoginResponse.java
@@ -23,6 +23,11 @@ public class LoginResponse {
     String username;
 
     /**
+     * Roles limit of signed in user
+     */
+    List<String> rolesLimit;
+
+    /**
      * User privileges from assemblyline-ui/blob/master/assemblyline_ui/api/v4/authentication.py
      */
     public enum Privleges {

--- a/src/test/java/ca/gc/cyber/ops/assemblyline/java/client/clients/MockResponseModels.java
+++ b/src/test/java/ca/gc/cyber/ops/assemblyline/java/client/clients/MockResponseModels.java
@@ -55,6 +55,7 @@ public final class MockResponseModels {
         deserialization we are testing.*/
         return LoginResponse.builder()
                 .privileges(List.of(LoginResponse.Privleges.R, LoginResponse.Privleges.W))
+                .rolesLimit(List.of("submission_create", "submission_delete", "submission_manage"))
                 .sessionDuration(300)
                 .username("test")
                 .build();

--- a/src/test/resources/MockResponseModels/login_response.json
+++ b/src/test/resources/MockResponseModels/login_response.json
@@ -3,7 +3,12 @@
   "api_response": {
     "privileges" : ["R", "W"],
     "session_duration" : 300,
-    "username" : "test"
+    "username" : "test",
+    "roles_limit": [
+      "submission_create",
+      "submission_delete",
+      "submission_manage"
+    ]
   },
   "api_server_version": "4.0.0",
   "api_status_code": 200


### PR DESCRIPTION
Assemblyline release v4.3.1.x introduces changes to it's API's response objects. This doesn't go well with strict json deserialization. 
From a Cbs use case, this is the only new key I was able to identify.