### PR TITLE
Manually configure required ObjectMapper settings

### DIFF
--- a/src/main/java/ca/gc/cyber/ops/assemblyline/java/client/clients/AssemblylineClient.java
+++ b/src/main/java/ca/gc/cyber/ops/assemblyline/java/client/clients/AssemblylineClient.java
@@ -24,8 +24,10 @@ import ca.gc.cyber.ops.assemblyline.java.client.responses.AssemblylineApiRespons
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
@@ -101,6 +103,8 @@ public class AssemblylineClient implements IAssemblylineClient {
         this.assemblylineAuthenticationMethod = assemblylineAuthenticationMethod;
         mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.registerModule(new JavaTimeModule());
         this.buildWebClient(assemblylineClientProperties, httpClient);
     }
 

--- a/src/test/java/ca/gc/cyber/ops/assemblyline/java/client/clients/AssemblylineClientTest.java
+++ b/src/test/java/ca/gc/cyber/ops/assemblyline/java/client/clients/AssemblylineClientTest.java
@@ -3,7 +3,9 @@ package ca.gc.cyber.ops.assemblyline.java.client.clients;
 import ca.gc.cyber.ops.assemblyline.java.client.AssemblylineClientConfig;
 import ca.gc.cyber.ops.assemblyline.java.client.model.DownloadFileParams;
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import lombok.Data;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -643,5 +645,23 @@ class AssemblylineClientTest {
         }
     }
 
+    @Test
+    void testMisconfiguredDefaultMapper() {
+        // Construct a client with an ObjectMapper that has missing/unexpected settings.
+        ObjectMapper mapper = new ObjectMapper();
+        // The client needs SNAKE_CASE
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
+        // The client should *not* fail on unknown properties, to be more accommodating of changes in AssemblyLine.
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
+        // The client constructor should be setting the required properties on the mapper inside the constructor.
+        assemblylineClient = new AssemblylineClient(assemblylineClientProperties, httpClient, mapper,
+                new AssemblylineAuthenticationTestImpl());
+
+        mockResponse(MockResponseModels.getFileInfoJson());
+
+        verifyHttpGet(this.assemblylineClient.getFileInfo("334d016f755cd6dc58c53a86e183882f8ec14f52fb05345887c8a5edd42c87b7"),
+                "/api/v4/file/info/334d016f755cd6dc58c53a86e183882f8ec14f52fb05345887c8a5edd42c87b7/",
+                MockResponseModels.getFileInfo());
+    }
 }

--- a/src/test/java/ca/gc/cyber/ops/assemblyline/java/client/clients/AssemblylineClientTest.java
+++ b/src/test/java/ca/gc/cyber/ops/assemblyline/java/client/clients/AssemblylineClientTest.java
@@ -649,15 +649,19 @@ class AssemblylineClientTest {
     void testMisconfiguredDefaultMapper() {
         // Construct a client with an ObjectMapper that has missing/unexpected settings.
         ObjectMapper mapper = new ObjectMapper();
-        // The client needs SNAKE_CASE
+        // The client needs SNAKE_CASE; set an incorrect value to make sure the client overrides it.
         mapper.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
-        // The client should *not* fail on unknown properties, to be more accommodating of changes in AssemblyLine.
+        // The client should *not* fail on unknown properties; set an incorrect value to make sure the client overrides it.
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
-        // The client constructor should be setting the required properties on the mapper inside the constructor.
+        // The client constructor should be overriding the incorrect properties on the mapper inside the constructor.
         assemblylineClient = new AssemblylineClient(assemblylineClientProperties, httpClient, mapper,
                 new AssemblylineAuthenticationTestImpl());
 
+        /* getFileInfo() isn't *necessarily* special, but the AL response includes
+                - A date (which can be used to verify that the client registered the JavaTimeModule with the mapper)
+                - An extra, "unexpected" field, which can be used to verify that the client is ignoring unknown fields.
+        */
         mockResponse(MockResponseModels.getFileInfoJson());
 
         verifyHttpGet(this.assemblylineClient.getFileInfo("334d016f755cd6dc58c53a86e183882f8ec14f52fb05345887c8a5edd42c87b7"),

--- a/src/test/resources/MockResponseModels/file_info.json
+++ b/src/test/resources/MockResponseModels/file_info.json
@@ -19,7 +19,8 @@
     "sha256": "334d016f755cd6dc58c53a86e183882f8ec14f52fb05345887c8a5edd42c87b7",
     "size": 6,
     "ssdeep": "3:at:at",
-    "type": "unknown"
+    "type": "unknown",
+    "a completely unexpected property": "To avoid breaking things, the client should ignore unknown properties in received JSON."
   },
   "api_server_version": "4.0.0",
   "api_status_code": 200


### PR DESCRIPTION
This partially addresses #26, by explicitly setting `FAIL_ON_UNKNOWN_PROPERTIES=false` and registering `JavaTimeModule` to handle `Instant`s. This pull request _does not_ remove the `ObjectMapper` parameter from the `AssemblyLineClient` constructor; I don't _think_ there's any reason to allow custom settings (we only use the mapper to read/write AL responses/requests), but I can't be sure.