### PR TITLE
support for submission_profile

### DIFF
--- a/src/main/java/ca/gc/cyber/ops/assemblyline/java/client/AssemblylineClientConfig.java
+++ b/src/main/java/ca/gc/cyber/ops/assemblyline/java/client/AssemblylineClientConfig.java
@@ -8,7 +8,6 @@ import ca.gc.cyber.ops.assemblyline.java.client.authentication.PasswordAuthentic
 import ca.gc.cyber.ops.assemblyline.java.client.clients.AssemblylineClient;
 import ca.gc.cyber.ops.assemblyline.java.client.clients.AssemblylineClientProperties;
 import ca.gc.cyber.ops.assemblyline.java.client.clients.IAssemblylineClient;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/src/main/java/ca/gc/cyber/ops/assemblyline/java/client/model/submit/SubmitBase.java
+++ b/src/main/java/ca/gc/cyber/ops/assemblyline/java/client/model/submit/SubmitBase.java
@@ -6,7 +6,6 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.Map;
 
-
 @SuperBuilder
 @Data
 @NoArgsConstructor
@@ -24,4 +23,8 @@ public class SubmitBase {
      * Submission Parameters
      */
     private Map<String, Object> params;
+    /**
+     * Submission profile name
+     */
+    private String submissionProfile;
 }

--- a/src/test/java/ca/gc/cyber/ops/assemblyline/java/client/clients/RequestModels.java
+++ b/src/test/java/ca/gc/cyber/ops/assemblyline/java/client/clients/RequestModels.java
@@ -44,6 +44,7 @@ public class RequestModels {
                 .sha256("abc256")
                 .metadata(Map.of("key", "value", "key2", new AssemblylineClientTest.MetadataObjectTest()))
                 .params(Map.of("param1", "value1"))
+                .submissionProfile("static")
                 .name("meta data")
                 .generateAlert(true)
                 .notificationQueue("notificationQueue")
@@ -56,6 +57,7 @@ public class RequestModels {
                 .sha256("abc256")
                 .metadata(Map.of("key", "value", "key2", new AssemblylineClientTest.MetadataObjectTest()))
                 .params(Map.of("param1", "value1"))
+                .submissionProfile("static")
                 .name("meta data")
                 .build();
     }
@@ -71,6 +73,7 @@ public class RequestModels {
                 .metadata(IngestBase.builder()
                         .metadata(Map.of("key", "value", "key2", new AssemblylineClientTest.MetadataObjectTest()))
                         .params(Map.of("param1", "value1"))
+                        .submissionProfile("static")
                         .name("meta data")
                         .generateAlert(true)
                         .notificationQueue("notificationQueue")
@@ -86,6 +89,7 @@ public class RequestModels {
                 .metadata(IngestBase.builder()
                         .metadata(Map.of("key", "value", "key2", new AssemblylineClientTest.MetadataObjectTest()))
                         .params(Map.of("param1", "value1"))
+                        .submissionProfile("static")
                         .name("meta data")
                         .generateAlert(true)
                         .notificationQueue("notificationQueue")
@@ -113,6 +117,7 @@ public class RequestModels {
                 .metadata(SubmitMetadata.builder()
                         .metadata(Map.of("key", "value", "key2", new AssemblylineClientTest.MetadataObjectTest()))
                         .params(Map.of("param1", "value1"))
+                        .submissionProfile("static")
                         .name("meta data")
                         .build())
                 .build();
@@ -127,6 +132,7 @@ public class RequestModels {
                 .url("/test/url.com")
                 .metadata(Map.of("key", "value", "key2", new AssemblylineClientTest.MetadataObjectTest()))
                 .params(Map.of("param1", "value1"))
+                .submissionProfile("static")
                 .name("meta data")
                 .generateAlert(true)
                 .notificationQueue("notificationQueue")
@@ -143,6 +149,7 @@ public class RequestModels {
                 .url("/test/url.com")
                 .metadata(Map.of("key", "value", "key2", new AssemblylineClientTest.MetadataObjectTest()))
                 .params(Map.of("param1", "value1"))
+                .submissionProfile("static")
                 .name("meta data")
                 .build();
     }

--- a/src/test/resources/MockRequestModels/binary_ingest.json
+++ b/src/test/resources/MockRequestModels/binary_ingest.json
@@ -6,6 +6,7 @@
       "field2": "test2"
     }
   },
+  "submission_profile": "static",
   "params": {
     "param1": "value1"
   },

--- a/src/test/resources/MockRequestModels/sha256_ingest.json
+++ b/src/test/resources/MockRequestModels/sha256_ingest.json
@@ -1,12 +1,13 @@
 {
-  "name":"meta data",
+  "name": "meta data",
   "metadata": {
     "key": "value",
-    "key2":{
+    "key2": {
       "field1": "test1",
       "field2": "test2"
     }
   },
+  "submission_profile": "static",
   "params": {
     "param1": "value1"
   },

--- a/src/test/resources/MockRequestModels/sha256_submit.json
+++ b/src/test/resources/MockRequestModels/sha256_submit.json
@@ -1,12 +1,13 @@
 {
-  "name":"meta data",
+  "name": "meta data",
   "metadata": {
     "key": "value",
-    "key2":{
+    "key2": {
       "field1": "test1",
       "field2": "test2"
     }
   },
+  "submission_profile": "static",
   "params": {
     "param1": "value1"
   },

--- a/src/test/resources/MockRequestModels/submit.json
+++ b/src/test/resources/MockRequestModels/submit.json
@@ -6,6 +6,7 @@
       "field2": "test2"
     }
   },
+  "submission_profile": "static",
   "params": {
     "param1": "value1"
   },

--- a/src/test/resources/MockRequestModels/url_ingest.json
+++ b/src/test/resources/MockRequestModels/url_ingest.json
@@ -11,6 +11,7 @@
   "params": {
     "param1": "value1"
   },
+  "submission_profile": "static",
   "generate_alert": true,
   "notification_queue": "notificationQueue",
   "notification_threshold": 100

--- a/src/test/resources/MockRequestModels/url_submit.json
+++ b/src/test/resources/MockRequestModels/url_submit.json
@@ -8,6 +8,7 @@
       "field2": "test2"
     }
   },
+  "submission_profile": "static",
   "params": {
     "param1": "value1"
   }


### PR DESCRIPTION
This pull request introduces a new `submissionProfile` field to the `SubmitBase` model and updates related test cases and mock data to accommodate this addition. Additionally, minor cleanup was performed in the codebase.

### New Feature: `submissionProfile` Field

* [`src/main/java/ca/gc/cyber/ops/assemblyline/java/client/model/submit/SubmitBase.java`](diffhunk://#diff-6378beaaa5bb90db81623ca98e307f3ac3bd6232a45e629070f44eaa26e28d4eR26-R29): Added the `submissionProfile` field to the `SubmitBase` class to represent the submission profile name.
* [`src/test/java/ca/gc/cyber/ops/assemblyline/java/client/clients/RequestModels.java`](diffhunk://#diff-731ad8ba3737913c72b1133835afea563c947d1ccbec4b18a5aa931c247ca1e9R47): Updated multiple test methods (`getSha256IngestObject`, `getSha256SubmitObject`, `getBinaryIngestObject`, `getAsyncBinaryIngestObject`, `getBinarySubmitObject`, `getUrlIngestObject`, `getUrlSubmitObject`) to include the `submissionProfile` field with a sample value of `"static"`. [[1]](diffhunk://#diff-731ad8ba3737913c72b1133835afea563c947d1ccbec4b18a5aa931c247ca1e9R47) [[2]](diffhunk://#diff-731ad8ba3737913c72b1133835afea563c947d1ccbec4b18a5aa931c247ca1e9R60) [[3]](diffhunk://#diff-731ad8ba3737913c72b1133835afea563c947d1ccbec4b18a5aa931c247ca1e9R76) [[4]](diffhunk://#diff-731ad8ba3737913c72b1133835afea563c947d1ccbec4b18a5aa931c247ca1e9R92) [[5]](diffhunk://#diff-731ad8ba3737913c72b1133835afea563c947d1ccbec4b18a5aa931c247ca1e9R120) [[6]](diffhunk://#diff-731ad8ba3737913c72b1133835afea563c947d1ccbec4b18a5aa931c247ca1e9R135) [[7]](diffhunk://#diff-731ad8ba3737913c72b1133835afea563c947d1ccbec4b18a5aa931c247ca1e9R152)
* Test mock data files (`binary_ingest.json`, `sha256_ingest.json`, `sha256_submit.json`, `submit.json`, `url_ingest.json`, `url_submit.json`) were updated to include the `submission_profile` field with a value of `"static"`. [[1]](diffhunk://#diff-23067f13ab30e4c299dadf270d37eb7939e2eb2a8910fb723319873619ea512dR9) [[2]](diffhunk://#diff-18110cb587913e7ed6ea1dcc58f8d1167bfb277a4f259456021604c6e1040448R10) [[3]](diffhunk://#diff-13125949760b16afc45a93239558be6576f92ee5cb5403ac787936431e70b8b6R10) [[4]](diffhunk://#diff-3e701ff4a6bc5d34de9687c63aac49a814429bbfcfe98a6cac2b97e9fa4c3000R9) [[5]](diffhunk://#diff-1be52ec0293fee9fbac0c61a92ca4d2b756dd11e333d12f41b67d907d94dadfcR14) [[6]](diffhunk://#diff-1821f8e0e184352cac1c02ce1e34c849bf0cd29ce948294e892a7668316b3f00R11)

### Code Cleanup

* [`src/main/java/ca/gc/cyber/ops/assemblyline/java/client/AssemblylineClientConfig.java`](diffhunk://#diff-95feaccada5c8a342cac1b61da1ac3649e51031921681163cdce3d5f2df616c8L11): Removed an unused import statement for `ObjectMapper`.
* [`src/main/java/ca/gc/cyber/ops/assemblyline/java/client/model/submit/SubmitBase.java`](diffhunk://#diff-6378beaaa5bb90db81623ca98e307f3ac3bd6232a45e629070f44eaa26e28d4eL9): Removed an unnecessary blank line for better formatting.